### PR TITLE
Add documentation to main project functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,77 @@
 
 A lightweight finite state machine library for typescript based on t-state
 
-TODO: Write dcoumentation here
+## Documentation
+
+### Overview
+
+`light-fsm` is a lightweight finite state machine (FSM) library designed for TypeScript applications. It leverages the `t-state` library to provide a simple yet powerful API for managing state transitions in a predictable manner.
+
+### Finite State Machine Concept
+
+A finite state machine is a computational model used to design algorithms. It consists of a finite number of states, transitions between those states, and actions that can occur in each state. `light-fsm` simplifies the process of defining and managing these states and transitions in your application.
+
+### Installation
+
+To install `light-fsm`, run the following command in your project directory:
+
+```bash
+npm install light-fsm
+```
+
+### Usage
+
+To use `light-fsm`, you first define the states and transitions of your machine. Here's a simple example:
+
+```typescript
+import { createFSM, FSMConfig } from 'light-fsm';
+
+type LightStates = 'green' | 'yellow' | 'red';
+type LightEvents = { type: 'TIMER' | 'POWER_OUTAGE' };
+
+const config: FSMConfig<{ states: LightStates; events: LightEvents }> = {
+  initial: 'green',
+  states: {
+    green: {
+      on: {
+        TIMER: 'yellow',
+      },
+    },
+    yellow: {
+      on: {
+        TIMER: 'red',
+      },
+    },
+    red: {
+      on: {
+        TIMER: 'green',
+        POWER_OUTAGE: 'red',
+      },
+    },
+  },
+};
+
+const trafficLight = createFSM(config);
+
+// Transition to the next state
+trafficLight.send({ type: 'TIMER' });
+```
+
+### Configuration Options
+
+The `FSMConfig` object allows you to define the initial state, states, and transitions of your finite state machine. Each state can define actions that occur on entry (`entry`), on exit (`exit`), or during transitions (`on`).
+
+### API Reference
+
+- `createFSM(config: FSMConfig)`: Creates a new finite state machine based on the provided configuration.
+- `send(event: Event)`: Triggers a state transition based on the given event.
+
+For more detailed information, please refer to the type definitions in the library.
+
+### Contributing
+
+Contributions to `light-fsm` are welcome! Please refer to the project's GitHub repository for contribution guidelines.
+
+### License
+
+`light-fsm` is licensed under the MIT License. See the LICENSE file for more details.

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,15 @@ type Target<P extends FSMProps> =
       action?: (args: ActionArgs<P>) => void;
     };
 
+/**
+ * Configuration object for the finite state machine.
+ * @typedef {Object} FSMConfig
+ * @property {string} initial - The initial state of the machine.
+ * @property {Object} states - The states of the machine and their configurations.
+ * @property {Object} [on] - State independent transitions.
+ * @property {Function} [handleInvalidTransition] - Function to handle invalid transitions.
+ * @property {string} [debug] - Debugging identifier.
+ */
 export type FSMConfig<P extends FSMProps> = {
   initial: P['states'];
   states: {
@@ -46,6 +55,11 @@ export type FSMConfig<P extends FSMProps> = {
   debug?: string;
 };
 
+/**
+ * Creates a finite state machine based on the provided configuration.
+ * @param {FSMConfig} config - The configuration object for the FSM.
+ * @returns An object representing the finite state machine.
+ */
 export function createFSM<Props extends FSMProps = never>({
   initial,
   states,


### PR DESCRIPTION
Related to #1

This pull request introduces comprehensive documentation to the `light-fsm` project, addressing the previously noted lack of documentation for the main project functions and the overall project in the `README.md` file.

- **Adds JSDoc comments**: Implements detailed JSDoc comments in `src/main.ts` for the `FSMConfig` type definition and the `createFSM` function, providing clear explanations of their purposes, parameters, and return types.
- **Updates `README.md`**: Replaces the TODO item with a detailed documentation section that includes an overview of the project, a brief explanation of the finite state machine concept, installation instructions, usage examples, configuration options, API reference, contributing guidelines, and licensing information.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/lucasols/light-fsm/issues/1?shareId=590f7658-e86b-4155-b3df-a82bf763e492).